### PR TITLE
MAINT: Add version constraints for mpi and plumed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set date = datetime.datetime.strptime(version, "%d%b%Y") %}
 {% set conda_version = "{:%Y.%m.%d}".format(date) %}
 
-{% set build = 0 %}
+{% set build = 1 %}
 {% set git_rev = "5eda6338cd4cf7ea50a203af4c7c0a3536d61e4e" %}
 # increase this by 1 everytime you change the git commit above without also
 # changing the `version`
@@ -74,15 +74,15 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi']
     - cuda-version {{ cuda_compiler_version }} # [cuda_compiler_version != "None"]
     - cuda-toolkit  {{ cuda_compiler_version }} # [cuda_compiler_version != "None"]
-    - fftw * {{ mpi_prefix }}_*
-    - plumed
+    - fftw * {{ mpi_prefix }}*
+    - plumed-metatomic * {{ mpi_prefix }}*
     - libmetatomic-torch >=0.1.0,<0.2.0
     # always build against the CPU version of libtorch, we can still pick the
     # cuda one at runtime
     - libtorch * cpu*
   run:
     - {{ mpi }}  # [mpi != 'nompi']
-    - plumed
+    - plumed-metatomic * {{ mpi_prefix }}*
     - libmetatomic-torch >=0.1.0,<0.2.0
     - libmetatensor-torch >=0.7.6,<0.8.0
     - libmetatensor >=0.1.14,<0.2.0


### PR DESCRIPTION
xref: issues with `lammps` and MPI...

```bash
# From @Luthaf 
$ conda install -c metatensor "lammps-metatomic=*=*nompi*_10003"
[...]

The following NEW packages will be INSTALLED:

[...]
  lammps-metatomic   metatensor/linux-aarch64::lammps-metatomic-2025.04.02.mta0-cpu_h06edeee_nompi_git.2a07d5b_10003
[...]
  plumed-metatomic   metatensor/linux-aarch64::plumed-metatomic-2.10.dev-mpi_openmpi_h0691d73_2002_gc_9a880de
[...]
```

Also...

```bash
micromamba install -c metatensor py-plumed-metatomic "plumed-metatomic=2.10.dev=*mpi_nompi*" lammps-metatomic
...
  + lammps-metatomic      2025.04.02.mta0  cpu_he59fe11_mpi_openmpi_git.2a07d5b_12003  metatensor      Cached
...
  + plumed-metatomic             2.10.dev  mpi_nompi_h830c8f5_2_gc_9a880de             metatensor      Cached


micromamba install -c metatensor py-plumed-metatomic "plumed-metatomic=2.10.dev=*mpi_nompi*" "lammps-metatomic=*=*nompi*_10003"
...
  + lammps-metatomic      2025.04.02.mta0  cpu_h3f4bae7_nompi_git.2a07d5b_10003  metatensor      Cached
...
  + py-plumed-metatomic          2.10.dev  h664a358_0_gc_9a880de                 metatensor      Cached
```

Draft until `conda smithy regenerate` is done.


Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.